### PR TITLE
Fixed problem that the value of Kana input field is empty.

### DIFF
--- a/kana/view/frontend/templates/customer/widget/jpname.phtml
+++ b/kana/view/frontend/templates/customer/widget/jpname.phtml
@@ -156,7 +156,7 @@ $kanaType = $block->getConfig('kana_type');
             <?php if(!is_null($attrLnameKana) && is_object($attrLnameKana)) :?>
                 <?php $lnameKana = $attrLnameKana->getValue();?>
             <?php elseif(is_object($block->getObject())) :?>
-                <?php if(method_exists($block->getObject(), 'getLastnamekana')):?>
+                <?php if(!is_null($block->getObject()->getLastnamekana())):?>
                     <?php $lnameKana = $block->getObject()->getLastnamekana();?>
                 <?php elseif (method_exists($block->getObject(), '__toArray') && array_key_exists('lastnamekana', $block->getObject()->__toArray())): ?>
                     <?php $lnameKana = $block->getObject()->getLastnamekana(); ?>
@@ -182,7 +182,7 @@ $kanaType = $block->getConfig('kana_type');
             <?php if(is_object($attrFnameKana)) :?>
                 <?php $fnameKana = $attrFnameKana->getValue();?>
             <?php elseif(is_object($block->getObject())) :?>
-                <?php if(method_exists($block->getObject(), 'getFirstnamekana')):?>
+                <?php if(!is_null($block->getObject()->getFirstnamekana())):?>
                     <?php $fnameKana = $block->getObject()->getFirstnamekana();?>
                 <?php elseif (method_exists($block->getObject(), '__toArray') && array_key_exists('firstnamekana', $block->getObject()->__toArray())): ?>
                     <?php $fnameKana = $block->getObject()->getFirstnamekana(); ?>

--- a/kana/view/frontend/templates/customer/widget/jpname.phtml
+++ b/kana/view/frontend/templates/customer/widget/jpname.phtml
@@ -147,8 +147,8 @@ $kanaType = $block->getConfig('kana_type');
         <?php endif;?>
         <?php $rule = join(',', $rule);?>
         <div class="field name lastname <?php if($requireKana):?>required<?php endif;?>">
-            <label class="label"  for="<?= $block->getFieldId('lastnamekana') ?>">
-                <span><?= $block->getStoreLabel('lastnamekana') ?></span>
+            <label class="label"  for="<?= $block->escapeHtmlAttr($block->getFieldId('lastnamekana')) ?>">
+                <span><?= $block->escapeHtml($block->getStoreLabel('lastnamekana')) ?></span>
             </label>
 
             <?php $attrLnameKana = $block->getObject()->getCustomAttribute('lastnamekana');?>
@@ -164,17 +164,17 @@ $kanaType = $block->getConfig('kana_type');
             <?php endif; ?>
 
             <div class="control">
-                <input type="text" id="<?= $block->getFieldId('lastnamekana') ?>"
-                       name="<?= $block->getFieldName('lastnamekana') ?>"
-                       value="<?php echo $block->escapeHtml($lnameKana) ?>"
-                       title="<?= $block->getStoreLabel('lastnamekana') ?>"
-                       class="input-text <?php echo $block->getAttributeValidationClass('lastnamekana') ?>" <?= $block->getFieldParams() ?>
+                <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('lastnamekana')) ?>"
+                       name="<?= $block->escapeHtmlAttr($block->getFieldName('lastnamekana')) ?>"
+                       value="<?= $block->escapeHtmlAttr($lnameKana) ?>"
+                       title="<?= $block->escapeHtmlAttr($block->getStoreLabel('lastnamekana')) ?>"
+                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('lastnamekana')) ?>" <?= $block->escapeHtmlAttr($block->getFieldParams()) ?>
                        <?php if ($rule): ?>data-validate="{<?= $rule; ?>}"<?php endif; ?>>
             </div>
         </div>
         <div class="field name firstname <?php if($requireKana):?>required<?php endif;?>">
-            <label class="label" for="<?= $block->getFieldId('firstnamekana') ?>">
-                <span><?= $block->getStoreLabel('firstnamekana') ?></span>
+            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('firstnamekana')) ?>">
+                <span><?= $block->escapeHtml($block->getStoreLabel('firstnamekana')) ?></span>
             </label>
 
             <?php $attrFnameKana = $block->getObject()->getCustomAttribute('firstnamekana');?>
@@ -189,11 +189,11 @@ $kanaType = $block->getConfig('kana_type');
                 <?php endif;?>
             <?php endif; ?>
             <div class="control">
-                <input type="text" id="<?= $block->getFieldId('firstnamekana') ?>"
-                       name="<?= $block->getFieldName('firstnamekana') ?>"
-                       value="<?php echo $block->escapeHtml($fnameKana) ?>"
-                       title="<?= $block->getStoreLabel('firstnamekana') ?>"
-                       class="input-text <?= $block->getAttributeValidationClass('firstnamekana') ?>" <?= $block->getFieldParams() ?>
+                <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('firstnamekana')) ?>"
+                       name="<?= $block->escapeHtmlAttr($block->getFieldName('firstnamekana')) ?>"
+                       value="<?= $block->escapeHtmlAttr($fnameKana) ?>"
+                       title="<?= $block->escapeHtmlAttr($block->getStoreLabel('firstnamekana')) ?>"
+                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('firstnamekana')) ?>" <?= $block->escapeHtmlAttr($block->getFieldParams()) ?>
                        <?php if ($rule): ?>data-validate="{<?= $rule; ?>}"<?php endif; ?>>
             </div>
         </div>


### PR DESCRIPTION
For example, in the member registration form, when the screen is updated with an error such as duplicate e-mail address, the kana input field becomes empty.
The cause is that method_exists() returns false even if there is a value.