### PR TITLE
会員ページ内会員情報変更フォームにて、カナが未登録の場合に例外が投げられていた不具合を修正

### DIFF
--- a/kana/view/frontend/templates/customer/widget/jpname.phtml
+++ b/kana/view/frontend/templates/customer/widget/jpname.phtml
@@ -156,10 +156,12 @@ $kanaType = $block->getConfig('kana_type');
             <?php if(!is_null($attrLnameKana) && is_object($attrLnameKana)) :?>
                 <?php $lnameKana = $attrLnameKana->getValue();?>
             <?php elseif(is_object($block->getObject())) :?>
-                <?php if(!is_null($block->getObject()->getLastnamekana())):?>
+                <?php if($block->getObject() instanceof \Magento\Framework\DataObject && !is_null($block->getObject()->getLastnamekana())):?>
+                    <?php $lnameKana = $block->getObject()->getLastnamekana();?>
+                <?php elseif(method_exists($block->getObject(), 'getLastnamekana') && !is_null($block->getObject()->getLastnamekana())):?>
                     <?php $lnameKana = $block->getObject()->getLastnamekana();?>
                 <?php elseif (method_exists($block->getObject(), '__toArray') && array_key_exists('lastnamekana', $block->getObject()->__toArray())): ?>
-                    <?php $lnameKana = $block->getObject()->getLastnamekana(); ?>
+                    <?php $lnameKana = $block->getObject()->__toArray()['lastnamekana']; ?>
                 <?php endif;?>
             <?php endif; ?>
 
@@ -179,15 +181,18 @@ $kanaType = $block->getConfig('kana_type');
 
             <?php $attrFnameKana = $block->getObject()->getCustomAttribute('firstnamekana');?>
             <?php $fnameKana = '';?>
-            <?php if(is_object($attrFnameKana)) :?>
+            <?php if(!is_null($attrFnameKana) && is_object($attrFnameKana)) :?>
                 <?php $fnameKana = $attrFnameKana->getValue();?>
             <?php elseif(is_object($block->getObject())) :?>
-                <?php if(!is_null($block->getObject()->getFirstnamekana())):?>
+                <?php if($block->getObject() instanceof \Magento\Framework\DataObject && !is_null($block->getObject()->getFirstnamekana())):?>
+                    <?php $lnameKana = $block->getObject()->getFirstnamekana();?>
+                <?php elseif(method_exists($block->getObject(), 'getFirstnamekana') && !is_null($block->getObject()->getFirstnamekana())):?>
                     <?php $fnameKana = $block->getObject()->getFirstnamekana();?>
                 <?php elseif (method_exists($block->getObject(), '__toArray') && array_key_exists('firstnamekana', $block->getObject()->__toArray())): ?>
-                    <?php $fnameKana = $block->getObject()->getFirstnamekana(); ?>
+                    <?php $fnameKana = $block->getObject()->__toArray()['firstnamekana']; ?>
                 <?php endif;?>
             <?php endif; ?>
+
             <div class="control">
                 <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('firstnamekana')) ?>"
                        name="<?= $block->escapeHtmlAttr($block->getFieldName('firstnamekana')) ?>"


### PR DESCRIPTION
#12 における修正により、会員ページ内で不具合が起きておりました。
大変失礼致しました。
`$block->getObject()` で得られるオブジェクトが、
会員登録フォームでは `Magento\Framework\DataObject` 、
会員ページ内のフォームでは `Magento\Customer\Model\Data\Address` 
という違いがあるのが原因であったため、DataObjectかどうかの判定を追加致しました。